### PR TITLE
Add Markdown → WeChat article formatter tool

### DIFF
--- a/tools/wechat-md/README.md
+++ b/tools/wechat-md/README.md
@@ -1,0 +1,46 @@
+# 公众号 Markdown 排版工具
+
+一个纯静态的 Markdown → 微信公众号编辑器排版工具，参考 mdnice / doocs-md 的思路。
+
+**在线使用**：部署到 GitHub Pages 后访问 `/tools/wechat-md/`。
+
+## 功能
+
+- 实时预览 Markdown 渲染效果
+- 三套内置主题（默认绿 / 优雅黑 / 暖橙）
+- 代码高亮（atom-one-light / github / vs2015 / monokai）
+- 自定义主色、字号
+- 一键复制带**内联样式**的 HTML，直接粘贴到公众号编辑器
+- 自动保存草稿到 localStorage
+- `Ctrl/Cmd + Enter` 快捷复制
+- 支持 GFM：表格、代码块、任务列表、删除线、链接识别
+
+## 实现要点
+
+| 部分 | 说明 |
+| --- | --- |
+| Markdown 解析 | `markdown-it` (CDN) |
+| 代码高亮 | `highlight.js` (CDN) |
+| 内联样式 | `getComputedStyle` 遍历预览 DOM，把主题 CSS 折叠成 `style` 属性 |
+| 伪元素 | `::before/::after` 的 `content` 展开为真实 `<span>` 节点 |
+| 剪贴板 | `ClipboardItem` + `text/html`，降级到 `execCommand('copy')` |
+
+公众号编辑器会剥掉 `class` 和外部样式表，只保留 `style` 属性，所以复制前必须把所有视觉效果"烧进" inline style，这是核心思路。
+
+## 目录
+
+```
+tools/wechat-md/
+├── index.html      页面骨架
+├── ui.css          工具链界面样式（不进入复制内容）
+├── app.js          渲染 + 主题切换 + 内联复制
+├── themes/
+│   ├── default.css 默认绿主题
+│   ├── elegant.css 优雅黑主题
+│   └── orange.css  暖橙主题
+└── README.md
+```
+
+## 新增主题
+
+复制任一 `themes/*.css`，所有选择器限定在 `.wechat-body` 内；然后在 `index.html` 的 `<select id="theme">` 添加一项即可。

--- a/tools/wechat-md/app.js
+++ b/tools/wechat-md/app.js
@@ -1,0 +1,323 @@
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'wechat-md-draft';
+  const STATE_KEY = 'wechat-md-state';
+
+  const editor = document.getElementById('editor');
+  const preview = document.getElementById('preview');
+  const themeSel = document.getElementById('theme');
+  const codeStyleSel = document.getElementById('codeStyle');
+  const primaryInput = document.getElementById('primary');
+  const fontSizeSel = document.getElementById('fontSize');
+  const copyBtn = document.getElementById('copy');
+  const sampleBtn = document.getElementById('sample');
+  const clearBtn = document.getElementById('clear');
+  const toast = document.getElementById('toast');
+  const codeThemeLink = document.getElementById('code-theme');
+
+  const md = window.markdownit({
+    html: false,
+    linkify: true,
+    breaks: false,
+    typographer: false,
+    highlight: function (str, lang) {
+      if (lang && window.hljs && hljs.getLanguage(lang)) {
+        try {
+          return hljs.highlight(str, { language: lang, ignoreIllegals: true }).value;
+        } catch (_) {}
+      }
+      if (window.hljs) {
+        try { return hljs.highlightAuto(str).value; } catch (_) {}
+      }
+      return '';
+    }
+  });
+
+  let themeLinkEl = null;
+  function loadTheme(name) {
+    if (themeLinkEl) themeLinkEl.remove();
+    themeLinkEl = document.createElement('link');
+    themeLinkEl.rel = 'stylesheet';
+    themeLinkEl.href = `themes/${name}.css`;
+    document.head.appendChild(themeLinkEl);
+  }
+
+  function loadCodeStyle(name) {
+    codeThemeLink.href = `https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/${name}.min.css`;
+  }
+
+  function applyPrimary(color) {
+    preview.style.setProperty('--primary', color);
+  }
+  function applyFontSize(size) {
+    preview.style.setProperty('font-size', size);
+  }
+
+  function render() {
+    const text = editor.value;
+    preview.innerHTML = md.render(text);
+    if (window.hljs) {
+      preview.querySelectorAll('pre code').forEach(block => {
+        if (!block.dataset.highlighted) {
+          block.classList.add('hljs');
+          block.dataset.highlighted = '1';
+        }
+      });
+    }
+    localStorage.setItem(STORAGE_KEY, text);
+  }
+
+  const COPY_PROPS = [
+    'color', 'background-color', 'background-image',
+    'font-family', 'font-size', 'font-weight', 'font-style',
+    'line-height', 'letter-spacing', 'text-align', 'text-indent',
+    'text-decoration-line', 'text-decoration-color', 'text-decoration-style',
+    'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+    'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+    'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
+    'border-top-style', 'border-right-style', 'border-bottom-style', 'border-left-style',
+    'border-top-color', 'border-right-color', 'border-bottom-color', 'border-left-color',
+    'border-top-left-radius', 'border-top-right-radius',
+    'border-bottom-left-radius', 'border-bottom-right-radius',
+    'display', 'width', 'max-width', 'height',
+    'white-space', 'word-break', 'overflow-x', 'position'
+  ];
+
+  function styleObjectToString(obj) {
+    return Object.entries(obj).map(([k, v]) => `${k}: ${v}`).join('; ');
+  }
+
+  function collectStyle(cs) {
+    const out = {};
+    for (const prop of COPY_PROPS) {
+      const v = cs.getPropertyValue(prop);
+      if (v && v !== 'normal' && v !== 'none' && v !== 'auto' && v !== '0px' && v !== 'rgba(0, 0, 0, 0)') {
+        out[prop] = v;
+      }
+    }
+    return out;
+  }
+
+  function inlineTree(sourceRoot, targetRoot) {
+    const srcList = [sourceRoot, ...sourceRoot.querySelectorAll('*')];
+    const tgtList = [targetRoot, ...targetRoot.querySelectorAll('*')];
+    for (let i = 0; i < srcList.length; i++) {
+      const src = srcList[i];
+      const tgt = tgtList[i];
+      if (!tgt) continue;
+      const cs = window.getComputedStyle(src);
+      const styleMap = collectStyle(cs);
+      tgt.setAttribute('style', styleObjectToString(styleMap));
+
+      ['::before', '::after'].forEach(pseudo => {
+        const pcs = window.getComputedStyle(src, pseudo);
+        const content = pcs.getPropertyValue('content');
+        if (content && content !== 'none' && content !== 'normal' && content !== '""') {
+          const text = content.replace(/^["']|["']$/g, '').replace(/\\([0-9a-fA-F]+)\s?/g, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+          if (!text) return;
+          const span = document.createElement('span');
+          span.textContent = text;
+          span.setAttribute('style', styleObjectToString(collectStyle(pcs)));
+          if (pseudo === '::before') tgt.insertBefore(span, tgt.firstChild);
+          else tgt.appendChild(span);
+        }
+      });
+    }
+    targetRoot.removeAttribute('class');
+    targetRoot.querySelectorAll('[class]').forEach(el => el.removeAttribute('class'));
+  }
+
+  function buildInlinedHTML() {
+    const clone = preview.cloneNode(true);
+    inlineTree(preview, clone);
+    return clone.outerHTML;
+  }
+
+  async function copyToWechat() {
+    if (!editor.value.trim()) {
+      showToast('内容为空');
+      return;
+    }
+    const html = buildInlinedHTML();
+    try {
+      if (window.ClipboardItem && navigator.clipboard && navigator.clipboard.write) {
+        const plain = preview.innerText;
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([html], { type: 'text/html' }),
+            'text/plain': new Blob([plain], { type: 'text/plain' })
+          })
+        ]);
+      } else {
+        fallbackCopyHTML(html);
+      }
+      showToast('已复制，去公众号编辑器粘贴即可 ✓');
+    } catch (e) {
+      console.error(e);
+      fallbackCopyHTML(html);
+      showToast('已复制（兼容模式）');
+    }
+  }
+
+  function fallbackCopyHTML(html) {
+    const box = document.createElement('div');
+    box.contentEditable = 'true';
+    box.style.cssText = 'position:fixed;left:-9999px;top:0;opacity:0';
+    box.innerHTML = html;
+    document.body.appendChild(box);
+    const range = document.createRange();
+    range.selectNodeContents(box);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    try { document.execCommand('copy'); } catch (_) {}
+    sel.removeAllRanges();
+    document.body.removeChild(box);
+  }
+
+  let toastTimer = null;
+  function showToast(msg) {
+    toast.textContent = msg;
+    toast.classList.add('show');
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toast.classList.remove('show'), 2200);
+  }
+
+  const SAMPLE = `# 示例：一篇公众号文章
+
+> 这是一个 Markdown 转公众号排版工具。左侧写作，右侧实时预览，一键复制到公众号编辑器。
+
+## 二级标题
+
+支持常见的 **加粗**、*斜体*、~~删除线~~、\`行内代码\` 和 [超链接](https://github.com)。
+
+### 三级标题
+
+无序列表：
+
+- 列表项一
+- 列表项二
+  - 嵌套列表项
+- 列表项三
+
+有序列表：
+
+1. 第一步
+2. 第二步
+3. 第三步
+
+### 代码块
+
+\`\`\`javascript
+function greet(name) {
+  const msg = \`Hello, \${name}!\`;
+  console.log(msg);
+  return msg;
+}
+
+greet('公众号');
+\`\`\`
+
+### 引用
+
+> 引用一段话，表达克制而优雅。
+> —— 某位作者
+
+### 表格
+
+| 框架 | 类型 | 特点 |
+| --- | --- | --- |
+| Hexo | 静态 | 插件丰富 |
+| Hugo | 静态 | 构建最快 |
+| Astro | 静态 | 组件化 |
+
+### 分隔线
+
+---
+
+### 图片
+
+![示例图片](https://via.placeholder.com/600x200/1aad19/ffffff?text=Sample+Image)
+
+排版完成后，点击右上角 **「复制到公众号」**，然后在公众号编辑器里直接粘贴即可。
+`;
+
+  function loadState() {
+    try {
+      const s = JSON.parse(localStorage.getItem(STATE_KEY) || '{}');
+      if (s.theme) { themeSel.value = s.theme; }
+      if (s.codeStyle) { codeStyleSel.value = s.codeStyle; }
+      if (s.primary) { primaryInput.value = s.primary; }
+      if (s.fontSize) { fontSizeSel.value = s.fontSize; }
+    } catch (_) {}
+  }
+  function saveState() {
+    localStorage.setItem(STATE_KEY, JSON.stringify({
+      theme: themeSel.value,
+      codeStyle: codeStyleSel.value,
+      primary: primaryInput.value,
+      fontSize: fontSizeSel.value
+    }));
+  }
+
+  function init() {
+    loadState();
+    loadTheme(themeSel.value);
+    loadCodeStyle(codeStyleSel.value);
+    applyPrimary(primaryInput.value);
+    applyFontSize(fontSizeSel.value);
+
+    const saved = localStorage.getItem(STORAGE_KEY);
+    editor.value = saved && saved.length ? saved : SAMPLE;
+    render();
+
+    editor.addEventListener('input', render);
+
+    themeSel.addEventListener('change', () => {
+      loadTheme(themeSel.value);
+      saveState();
+    });
+    codeStyleSel.addEventListener('change', () => {
+      loadCodeStyle(codeStyleSel.value);
+      saveState();
+    });
+    primaryInput.addEventListener('input', () => {
+      applyPrimary(primaryInput.value);
+      saveState();
+    });
+    fontSizeSel.addEventListener('change', () => {
+      applyFontSize(fontSizeSel.value);
+      saveState();
+    });
+
+    copyBtn.addEventListener('click', copyToWechat);
+    sampleBtn.addEventListener('click', () => {
+      editor.value = SAMPLE;
+      render();
+    });
+    clearBtn.addEventListener('click', () => {
+      if (editor.value && !confirm('确定清空当前内容？')) return;
+      editor.value = '';
+      render();
+    });
+
+    editor.addEventListener('keydown', (e) => {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = editor.selectionStart, end = editor.selectionEnd;
+        editor.setRangeText('  ', start, end, 'end');
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        copyToWechat();
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/tools/wechat-md/index.html
+++ b/tools/wechat-md/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Markdown → 公众号排版</title>
+<link rel="stylesheet" href="ui.css">
+<link id="code-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/atom-one-light.min.css">
+<script src="https://cdn.jsdelivr.net/npm/markdown-it@14.1.0/dist/markdown-it.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/highlight.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js"></script>
+</head>
+<body>
+<header class="toolbar">
+  <div class="brand">
+    <span class="logo">MD</span>
+    <span>公众号排版工具</span>
+  </div>
+  <div class="controls">
+    <label>主题
+      <select id="theme">
+        <option value="default">默认绿</option>
+        <option value="elegant">优雅黑</option>
+        <option value="orange">暖橙</option>
+      </select>
+    </label>
+    <label>代码
+      <select id="codeStyle">
+        <option value="atom-one-light">atom-one-light</option>
+        <option value="github">github</option>
+        <option value="vs2015">vs2015</option>
+        <option value="monokai">monokai</option>
+      </select>
+    </label>
+    <label>主色
+      <input type="color" id="primary" value="#1aad19">
+    </label>
+    <label>字号
+      <select id="fontSize">
+        <option value="14px">14</option>
+        <option value="15px" selected>15</option>
+        <option value="16px">16</option>
+        <option value="17px">17</option>
+      </select>
+    </label>
+    <button id="sample" class="btn btn-ghost">示例</button>
+    <button id="clear" class="btn btn-ghost">清空</button>
+    <button id="copy" class="btn btn-primary">复制到公众号</button>
+  </div>
+</header>
+<main class="split">
+  <section class="pane">
+    <div class="pane-header">Markdown</div>
+    <textarea id="editor" spellcheck="false" placeholder="在此粘贴或撰写 Markdown …"></textarea>
+  </section>
+  <section class="pane preview-pane">
+    <div class="pane-header">预览</div>
+    <div class="preview-scroll">
+      <section id="preview" class="wechat-body"></section>
+    </div>
+  </section>
+</main>
+<div id="toast" class="toast"></div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/tools/wechat-md/themes/default.css
+++ b/tools/wechat-md/themes/default.css
@@ -1,0 +1,125 @@
+/* 默认绿 - 参考公众号常见排版 */
+.wechat-body {
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  font-size: 15px;
+  line-height: 1.75;
+  color: #3f3f3f;
+  letter-spacing: 0.05em;
+  word-break: break-word;
+}
+.wechat-body h1, .wechat-body h2, .wechat-body h3,
+.wechat-body h4, .wechat-body h5, .wechat-body h6 {
+  margin: 1.4em 0 0.8em;
+  font-weight: 700;
+  color: #2f2f2f;
+  line-height: 1.4;
+}
+.wechat-body h1 {
+  font-size: 22px;
+  text-align: center;
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--primary, #1aad19);
+}
+.wechat-body h2 {
+  font-size: 19px;
+  padding: 4px 12px;
+  color: #fff;
+  background: var(--primary, #1aad19);
+  border-radius: 4px;
+  display: inline-block;
+}
+.wechat-body h3 {
+  font-size: 17px;
+  padding-left: 10px;
+  border-left: 4px solid var(--primary, #1aad19);
+}
+.wechat-body h4 { font-size: 16px; color: var(--primary, #1aad19); }
+.wechat-body h5 { font-size: 15px; }
+.wechat-body h6 { font-size: 14px; color: #888; }
+
+.wechat-body p {
+  margin: 1em 0;
+  line-height: 1.75;
+}
+.wechat-body strong { color: var(--primary, #1aad19); font-weight: 700; }
+.wechat-body em { color: #555; font-style: italic; }
+.wechat-body del { color: #999; }
+
+.wechat-body a {
+  color: var(--primary, #1aad19);
+  text-decoration: none;
+  border-bottom: 1px solid var(--primary, #1aad19);
+}
+
+.wechat-body blockquote {
+  margin: 1em 0;
+  padding: 12px 16px;
+  background: #f7f7f7;
+  border-left: 4px solid var(--primary, #1aad19);
+  color: #555;
+  border-radius: 0 4px 4px 0;
+}
+.wechat-body blockquote p { margin: 0; }
+
+.wechat-body ul, .wechat-body ol {
+  margin: 1em 0;
+  padding-left: 1.6em;
+}
+.wechat-body li { margin: 0.4em 0; }
+.wechat-body ul li::marker { color: var(--primary, #1aad19); }
+
+.wechat-body code {
+  padding: 2px 6px;
+  margin: 0 2px;
+  font-size: 0.9em;
+  background: #f3f4f6;
+  color: #c7254e;
+  border-radius: 3px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+}
+.wechat-body pre {
+  margin: 1em 0;
+  padding: 16px;
+  background: #f6f8fa;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+}
+.wechat-body pre code {
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  color: #333;
+  font-size: 13px;
+  border-radius: 0;
+}
+
+.wechat-body img {
+  max-width: 100%;
+  display: block;
+  margin: 1em auto;
+  border-radius: 4px;
+}
+
+.wechat-body hr {
+  border: none;
+  border-top: 1px dashed #ccc;
+  margin: 2em 0;
+}
+
+.wechat-body table {
+  width: 100%;
+  margin: 1em 0;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.wechat-body th, .wechat-body td {
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+  text-align: left;
+}
+.wechat-body th {
+  background: #f7f7f7;
+  font-weight: 600;
+}

--- a/tools/wechat-md/themes/elegant.css
+++ b/tools/wechat-md/themes/elegant.css
@@ -1,0 +1,135 @@
+/* 优雅黑 - 衬线风格、克制 */
+.wechat-body {
+  font-family: Georgia, "Songti SC", "Noto Serif SC", "Source Han Serif SC", serif;
+  font-size: 15px;
+  line-height: 1.9;
+  color: #2c2c2c;
+  letter-spacing: 0.04em;
+  word-break: break-word;
+}
+.wechat-body h1, .wechat-body h2, .wechat-body h3,
+.wechat-body h4, .wechat-body h5, .wechat-body h6 {
+  margin: 1.6em 0 0.8em;
+  font-weight: 700;
+  color: #111;
+  line-height: 1.4;
+  font-family: inherit;
+}
+.wechat-body h1 {
+  font-size: 24px;
+  text-align: center;
+  letter-spacing: 0.12em;
+}
+.wechat-body h1::after {
+  content: "";
+  display: block;
+  width: 40px;
+  height: 2px;
+  background: var(--primary, #222);
+  margin: 12px auto 0;
+}
+.wechat-body h2 {
+  font-size: 20px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #ddd;
+}
+.wechat-body h3 {
+  font-size: 17px;
+  color: var(--primary, #222);
+}
+.wechat-body h3::before {
+  content: "§ ";
+  color: #888;
+}
+.wechat-body h4 { font-size: 16px; }
+.wechat-body h5 { font-size: 15px; color: #666; }
+.wechat-body h6 { font-size: 14px; color: #888; }
+
+.wechat-body p {
+  margin: 1.1em 0;
+  text-indent: 2em;
+}
+.wechat-body strong { font-weight: 700; color: #000; }
+.wechat-body em { font-style: italic; color: #555; }
+.wechat-body del { color: #999; }
+
+.wechat-body a {
+  color: var(--primary, #222);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--primary, #222);
+}
+
+.wechat-body blockquote {
+  margin: 1.4em 0;
+  padding: 8px 20px;
+  border-left: 3px solid #222;
+  color: #666;
+  font-style: italic;
+  background: transparent;
+}
+.wechat-body blockquote p { margin: 0.4em 0; text-indent: 0; }
+
+.wechat-body ul, .wechat-body ol {
+  margin: 1em 0;
+  padding-left: 1.8em;
+}
+.wechat-body li { margin: 0.4em 0; }
+.wechat-body li p { text-indent: 0; margin: 0.2em 0; }
+
+.wechat-body code {
+  padding: 2px 6px;
+  font-size: 0.9em;
+  background: #f0f0f0;
+  color: #c7254e;
+  border-radius: 2px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+}
+.wechat-body pre {
+  margin: 1.2em 0;
+  padding: 18px;
+  background: #282c34;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #abb2bf;
+}
+.wechat-body pre code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 13px;
+}
+
+.wechat-body img {
+  max-width: 100%;
+  display: block;
+  margin: 1.2em auto;
+}
+
+.wechat-body hr {
+  border: none;
+  text-align: center;
+  margin: 2em 0;
+}
+.wechat-body hr::before {
+  content: "· · ·";
+  color: #999;
+  letter-spacing: 0.8em;
+}
+
+.wechat-body table {
+  width: 100%;
+  margin: 1.2em 0;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.wechat-body th, .wechat-body td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #e0e0e0;
+  text-align: left;
+}
+.wechat-body th {
+  border-bottom: 2px solid #222;
+  font-weight: 700;
+}

--- a/tools/wechat-md/themes/orange.css
+++ b/tools/wechat-md/themes/orange.css
@@ -1,0 +1,136 @@
+/* 暖橙 - 活泼温暖 */
+.wechat-body {
+  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  font-size: 15px;
+  line-height: 1.75;
+  color: #4a4a4a;
+  letter-spacing: 0.05em;
+  word-break: break-word;
+}
+.wechat-body h1, .wechat-body h2, .wechat-body h3,
+.wechat-body h4, .wechat-body h5, .wechat-body h6 {
+  margin: 1.5em 0 0.8em;
+  font-weight: 700;
+  line-height: 1.4;
+  color: #333;
+}
+.wechat-body h1 {
+  font-size: 22px;
+  text-align: center;
+  color: var(--primary, #ff7e3b);
+}
+.wechat-body h2 {
+  font-size: 19px;
+  position: relative;
+  padding-left: 14px;
+}
+.wechat-body h2::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 6px; bottom: 6px;
+  width: 5px;
+  background: linear-gradient(180deg, var(--primary, #ff7e3b), #ffc08a);
+  border-radius: 3px;
+}
+.wechat-body h3 {
+  font-size: 17px;
+  color: var(--primary, #ff7e3b);
+}
+.wechat-body h3::before {
+  content: "# ";
+  color: #ffc08a;
+}
+.wechat-body h4 { font-size: 16px; }
+.wechat-body h5 { font-size: 15px; color: #666; }
+.wechat-body h6 { font-size: 14px; color: #888; }
+
+.wechat-body p {
+  margin: 1em 0;
+}
+.wechat-body strong {
+  color: var(--primary, #ff7e3b);
+  font-weight: 700;
+  background: linear-gradient(180deg, transparent 60%, rgba(255,192,138,0.4) 60%);
+}
+.wechat-body em { color: #888; font-style: italic; }
+.wechat-body del { color: #bbb; }
+
+.wechat-body a {
+  color: var(--primary, #ff7e3b);
+  text-decoration: none;
+  border-bottom: 1px solid var(--primary, #ff7e3b);
+}
+
+.wechat-body blockquote {
+  margin: 1em 0;
+  padding: 12px 18px;
+  background: #fff6ef;
+  border-left: 4px solid var(--primary, #ff7e3b);
+  color: #7a5a47;
+  border-radius: 0 6px 6px 0;
+}
+.wechat-body blockquote p { margin: 0.2em 0; }
+
+.wechat-body ul, .wechat-body ol {
+  margin: 1em 0;
+  padding-left: 1.6em;
+}
+.wechat-body li { margin: 0.4em 0; }
+.wechat-body ul li::marker { color: var(--primary, #ff7e3b); }
+
+.wechat-body code {
+  padding: 2px 6px;
+  margin: 0 2px;
+  font-size: 0.9em;
+  background: #fff3e6;
+  color: #d2691e;
+  border-radius: 3px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+}
+.wechat-body pre {
+  margin: 1em 0;
+  padding: 16px;
+  background: #fffaf4;
+  border: 1px solid #ffe3c7;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+}
+.wechat-body pre code {
+  padding: 0;
+  background: transparent;
+  color: #5a3a1a;
+  font-size: 13px;
+}
+
+.wechat-body img {
+  max-width: 100%;
+  display: block;
+  margin: 1em auto;
+  border-radius: 6px;
+}
+
+.wechat-body hr {
+  border: none;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--primary, #ff7e3b), transparent);
+  margin: 2em 0;
+}
+
+.wechat-body table {
+  width: 100%;
+  margin: 1em 0;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.wechat-body th, .wechat-body td {
+  padding: 8px 12px;
+  border: 1px solid #ffe3c7;
+  text-align: left;
+}
+.wechat-body th {
+  background: #fff3e6;
+  color: #7a5a47;
+  font-weight: 600;
+}

--- a/tools/wechat-md/ui.css
+++ b/tools/wechat-md/ui.css
@@ -1,0 +1,151 @@
+*, *::before, *::after { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  color: #222;
+  background: #f5f6f8;
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  font-size: 15px;
+}
+.brand .logo {
+  display: inline-flex;
+  width: 28px; height: 28px;
+  align-items: center; justify-content: center;
+  background: #1aad19; color: #fff;
+  border-radius: 6px;
+  font-weight: 700; font-size: 12px;
+  letter-spacing: 0.5px;
+}
+.controls {
+  display: flex; align-items: center; gap: 10px;
+  flex-wrap: wrap;
+}
+.controls label {
+  display: inline-flex; align-items: center; gap: 6px;
+  color: #555; font-size: 13px;
+}
+.controls select, .controls input[type="color"] {
+  height: 30px;
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  background: #fff;
+  padding: 0 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.controls input[type="color"] {
+  width: 36px; padding: 2px;
+}
+.btn {
+  height: 30px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.btn-ghost {
+  background: #fff;
+  border-color: #d9d9d9;
+  color: #444;
+}
+.btn-ghost:hover { border-color: #1aad19; color: #1aad19; }
+.btn-primary {
+  background: #1aad19;
+  color: #fff;
+}
+.btn-primary:hover { background: #159913; }
+
+.split {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+}
+.pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid #e5e7eb;
+  background: #fff;
+}
+.pane:last-child { border-right: none; }
+.pane-header {
+  padding: 8px 14px;
+  font-size: 12px;
+  color: #888;
+  background: #fafafa;
+  border-bottom: 1px solid #f0f0f0;
+  letter-spacing: 0.5px;
+}
+#editor {
+  flex: 1;
+  width: 100%;
+  padding: 18px 20px;
+  border: none;
+  outline: none;
+  resize: none;
+  font: 14px/1.7 "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  color: #333;
+  background: #fff;
+  tab-size: 2;
+}
+.preview-pane { background: #f0f2f5; }
+.preview-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+#preview {
+  max-width: 677px;
+  margin: 0 auto;
+  padding: 30px 24px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  min-height: 200px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 32px; left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: rgba(30,30,30,0.92);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 6px;
+  font-size: 13px;
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.25s;
+  z-index: 100;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+@media (max-width: 860px) {
+  .split { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; }
+  .pane { border-right: none; border-bottom: 1px solid #e5e7eb; }
+}


### PR DESCRIPTION
## Summary

新增一个纯静态的 Markdown 排版工具，路径 `/tools/wechat-md/`，用于把 Markdown 一键转成可粘贴到微信公众号编辑器的富文本（带内联样式）。

- 实时预览 + 三套主题（默认绿 / 优雅黑 / 暖橙）
- 代码语法高亮（atom-one-light / github / vs2015 / monokai 可切换）
- 自定义主色与字号；草稿自动存 localStorage
- 一键复制：遍历预览 DOM 用 `getComputedStyle` 把样式折叠成 `style` 属性，并把 `::before/::after` 的 `content` 展开成真实 `<span>`，规避公众号编辑器剥离 class 和外部样式的限制
- `Ctrl/Cmd + Enter` 快捷复制；`Tab` 插入两空格缩进

## 文件结构

```
tools/wechat-md/
├── index.html       页面骨架
├── ui.css           工具链界面样式
├── app.js           渲染 + 主题切换 + 内联复制
├── themes/
│   ├── default.css
│   ├── elegant.css
│   └── orange.css
└── README.md
```

## 上线后访问

合并后通过 GitHub Pages 访问：
`https://lunring.github.io/tools/wechat-md/`

## Test plan

- [ ] 合并后等待 GitHub Pages 构建完成
- [ ] 打开线上链接，编辑器能加载示例并实时渲染
- [ ] 切换主题、改主色、改字号，预览实时更新
- [ ] 点击「复制到公众号」浏览器允许剪贴板权限后提示成功
- [ ] 在微信公众号后台编辑器粘贴，验证标题/列表/引用/代码块/表格样式都保留

https://claude.ai/code/session_01D6rDyd7GRDJtnEt6nXRRj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6rDyd7GRDJtnEt6nXRRj2)_